### PR TITLE
query example readmes & render on condition

### DIFF
--- a/src/components/ScannerExamples.js
+++ b/src/components/ScannerExamples.js
@@ -3,7 +3,7 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import "react-tabs/style/react-tabs.css";
 import Collapsible from "./Collapsible";
 
-export default function ScannerExamples({ examples, descriptions = [] }) {
+export default function ScannerExamples({ examples }) {
   return (
     <div className="container-fluid">
       <h2 className="title">Examples</h2>

--- a/src/components/ScannerExamples.js
+++ b/src/components/ScannerExamples.js
@@ -1,61 +1,49 @@
-import groupBy from 'lodash/groupBy';
-import mapValues from 'lodash/mapValues';
-import React from 'react';
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import 'react-tabs/style/react-tabs.css';
-import Collapsible from './Collapsible';
+import React from "react";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+import "react-tabs/style/react-tabs.css";
+import Collapsible from "./Collapsible";
 
-export default function ScannerExamples({
-  examples: allExamples,
-  descriptions: allDescriptions,
-}) {
-  const exampleGroups = mapValues(
-    groupBy(allExamples, ({ scanTarget }) => scanTarget),
-    (examples) => {
-      /* We are reversing to ensure that the right text ist displayed for the right file */
-      return examples.reverse();
-    }
-  );
-
+export default function ScannerExamples({ examples, descriptions = [] }) {
   return (
     <div className="container-fluid">
       <h2 className="title">Examples</h2>
 
-      {Object.entries(exampleGroups).map(([targetName, examples]) => {
+      {examples.map(({ name, description, scan, findings }) => {
         return (
-          <Tabs key={targetName}>
+          <Tabs key={name}>
             <Collapsible
               overflowWhenOpen="visible"
               lazyRender={true}
               transitionTime={150}
               transitionCloseTime={50}
-              trigger={targetName}
+              trigger={name}
               triggerTagName="h3"
             >
-              {allDescriptions.some(
-                (x) => x.node.frontmatter.title === targetName
-              ) && (
+              {description && (
                 <div
                   dangerouslySetInnerHTML={{
-                    __html: allDescriptions.find(
-                      (x) => x.node.frontmatter.title === targetName
-                    ).node.html,
+                    __html: description,
                   }}
                 ></div>
               )}
               <TabList>
-                {examples.map(({ fileName }) => (
-                  <Tab key={fileName}>{fileName.split('.')[0]}</Tab>
-                ))}
+                {scan && <Tab key={"scan"}>Scan</Tab>}
+                {findings && <Tab key={"findings"}>Findings</Tab>}
               </TabList>
-
-              {examples.map(({ fileName, content }) => (
-                <TabPanel key={fileName}>
+              {scan && (
+                <TabPanel key={"scan"}>
                   <deckgo-highlight-code theme="cobalt">
-                    <code slot="code">{content}</code>
+                    <code slot="code">{scan}</code>
                   </deckgo-highlight-code>
                 </TabPanel>
-              ))}
+              )}
+              {findings && (
+                <TabPanel key={"findings"}>
+                  <deckgo-highlight-code theme="cobalt">
+                    <code slot="code">{findings}</code>
+                  </deckgo-highlight-code>
+                </TabPanel>
+              )}
             </Collapsible>
           </Tabs>
         );

--- a/src/components/ScannerExamples.js
+++ b/src/components/ScannerExamples.js
@@ -5,7 +5,10 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import 'react-tabs/style/react-tabs.css';
 import Collapsible from './Collapsible';
 
-export default function ScannerExamples({ examples: allExamples }) {
+export default function ScannerExamples({
+  examples: allExamples,
+  descriptions: allDescriptions,
+}) {
   const exampleGroups = mapValues(
     groupBy(allExamples, ({ scanTarget }) => scanTarget),
     (examples) => {
@@ -29,6 +32,17 @@ export default function ScannerExamples({ examples: allExamples }) {
               trigger={targetName}
               triggerTagName="h3"
             >
+              {allDescriptions.some(
+                (x) => x.node.frontmatter.title === targetName
+              ) && (
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: allDescriptions.find(
+                      (x) => x.node.frontmatter.title === targetName
+                    ).node.html,
+                  }}
+                ></div>
+              )}
               <TabList>
                 {examples.map(({ fileName }) => (
                   <Tab key={fileName}>{fileName.split('.')[0]}</Tab>

--- a/src/templates/integration.js
+++ b/src/templates/integration.js
@@ -1,10 +1,10 @@
-import React from "react";
-import { graphql } from "gatsby";
-import Layout from "../components/Layout";
-import ScannerExamples from "../components/ScannerExamples.js";
-import Sidebar from "../components/Sidebar.js";
+import { defineCustomElements as deckDeckGoHighlightElement } from '@deckdeckgo/highlight-code/dist/loader';
+import { graphql } from 'gatsby';
+import React from 'react';
+import Layout from '../components/Layout';
+import ScannerExamples from '../components/ScannerExamples.js';
+import Sidebar from '../components/Sidebar.js';
 
-import { defineCustomElements as deckDeckGoHighlightElement } from "@deckdeckgo/highlight-code/dist/loader";
 deckDeckGoHighlightElement();
 
 const Integration = (props) => {
@@ -17,18 +17,19 @@ const Integration = (props) => {
 
   const examples = props.data.examples.nodes.map(({ fields }) => fields);
   const showExamples = examples.length > 0;
+  const exampleReadMes = props.data.exampleReadMes.edges;
 
   return (
     <Layout bodyClass="integration">
       <div className="sidebar-wrapper">
         <Sidebar
           categories={[
-            { categoryName: "Scanners", entries: scanners },
+            { categoryName: 'Scanners', entries: scanners },
             {
-              categoryName: "Persistence Providers",
+              categoryName: 'Persistence Providers',
               entries: persistenceProviders,
             },
-            { categoryName: "Hooks", entries: hooks },
+            { categoryName: 'Hooks', entries: hooks },
           ]}
           currentPathname={props.location.pathname}
         />
@@ -39,7 +40,7 @@ const Integration = (props) => {
               className="content"
               dangerouslySetInnerHTML={{ __html: html }}
             />
-            {showExamples && <ScannerExamples examples={examples} />}
+            {showExamples && <ScannerExamples examples={examples} descriptions={exampleReadMes} />}
           </div>
         </div>
       </div>
@@ -138,6 +139,18 @@ export const query = graphql`
           content
           fileName
           scanTarget
+        }
+      }
+    }
+    exampleReadMes: allMarkdownRemark(
+      filter: { fileAbsolutePath: { regex: $exampleFilter } }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            title
+          }
+          html
         }
       }
     }


### PR DESCRIPTION
Currently there's one example README.md for the amass example.com target. 
The example READMEs require a frontmatter with the field: `title: <targetName>`.